### PR TITLE
compile with all available cpu cores

### DIFF
--- a/build_git.sh
+++ b/build_git.sh
@@ -14,6 +14,6 @@ export CFLAGS="${CFLAGS} -static"
 
 make configure
 ./configure prefix=/root/output
-make
+make -j $(nproc)
 make install
 make clean


### PR DESCRIPTION
on multi-core systems, this may significantly speed up the git compiling process.
on my laptop with 4 cpu cores rolling Intel Core i7-8565U, this speeds up the git compile process from 
real	3m6,341s
to
real	1m17,921s

(that's reduction of 57% ! but varies widely by cpu)

- PS this may also significantly increase RAM consumption while compiling on multi-core systems, but generally there is a correlation between system RAM and number of cores (ie systems with lots of cpu cores usually have lots of ram as well)